### PR TITLE
Fix Bug on UploadId

### DIFF
--- a/src/StravaSharp/Activity.cs
+++ b/src/StravaSharp/Activity.cs
@@ -24,7 +24,7 @@ namespace StravaSharp
         public string ExternalId { get; internal set; }
 
         [JsonProperty("upload_id", NullValueHandling = NullValueHandling.Ignore)]
-        public int UploadId { get; internal set; }
+        public long UploadId { get; internal set; }
 
         [JsonProperty("name")]
         public string Name { get; internal set; }


### PR DESCRIPTION
The upload_id Strava json, has reached the int limit, so the library can't import Activities anymore.  long on UploadId is needed