### PR TITLE
Update Authenticator sample as per new api change.

### DIFF
--- a/src/Samples/Sample.Web/Controllers/HomeController.cs
+++ b/src/Samples/Sample.Web/Controllers/HomeController.cs
@@ -37,7 +37,7 @@ namespace Sample.Web.Controllers
                 ClientId = Config.ClientId,
                 ClientSecret = Config.ClientSecret,
                 RedirectUri = redirectUrl,
-                Scope = "view_private",
+                Scope = "activity:read_all",
             };
             var client = new StravaClient(new Authentication.RequestFactory(), config);
 


### PR DESCRIPTION
Very minor update to the Authenicator examples, as per the change implemented by Strava on 15/10/19 to not accept the view_private scope anymore.