### PR TITLE
LatLongConverter Error control on [] or null

### DIFF
--- a/src/StravaSharp/LatLng.cs
+++ b/src/StravaSharp/LatLng.cs
@@ -51,11 +51,13 @@ namespace StravaSharp
                 return null;
 
             var result = serializer.Deserialize<float[]>(reader);
-            return new LatLng
-            {
-                Latitude = result[0],
-                Longitude = result[1]
-            };
+            if (result != null && result.Length == 2)
+                return new LatLng
+                {
+                    Latitude = result[0],
+                    Longitude = result[1]
+                };
+            else return null;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
In some cases STRAVA send the ActivitySummary in a not valid format for LatLong:
....
"start_latlng": [],
"end_latlng": [],
....

In those cases, the parser fails with a OutOfRangeException. 
This PR prevent from this case